### PR TITLE
server migration 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,15 +18,6 @@ jobs:
       && contains('main development', github.event.workflow_run.head_branch)
     runs-on: ubuntu-latest
     steps:
-      - name: SSH into EC2 and deploy
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            cd /home/${{ secrets.EC2_USERNAME }}
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/readup-server
-            docker compose down
-            docker compose up -d
-            docker system prune -f
+      - name: Deploy to Coolify
+        run: |
+          curl --request GET '${{ secrets.COOLIFY_WEBHOOK }}' --header 'Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ FROM openjdk:21-jdk-slim
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 
+EXPOSE 8080
+
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,8 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
+      repositories:
+        enabled: false
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## 🔖 연관된 이슈
<!-- 연관된 이슈 번호를 작성해 주세요 -->

## 📂 작업 내용
<!-- 작업한 내용을 작성해 주세요 -->

redis를 localhost가 아닌 원격 elasticache redis로 옮기면서 java server 관련 에러가 났었습니다. 찾아보니  Repository scan 문제라고 하여 우선 돌아가도록 고쳤습니다. 백엔드 분들이 확인한번씩 해주시면 감사 할 것 같습니다. 

- ~~JPA Repository(@EnableJpaRepositories) 스캔 범위를 com.readup.server.auth.infrastructure로 명확히 분리하는 설정 클래스(JpaConfig) 추가~~
  - -> Redis Repository disable
- Spring Data JPA와 RedisTemplate 혼용 시 발생하는 Repository 인식 오류 방지
- Dockerfile EXPOSE 8080 추가 

## 📢 리뷰 참고사항
<!-- 리뷰시 참고사항을 작성해 주세요 -->

https://velog.io/@daoh98/SpringJPA-Redis-Repository-scan-%EB%AC%B8%EC%A0%9C
https://velog.io/@kws60000/Could-not-safely-identify-store-assignment-for-repository-candidate-interface
https://lahuman.github.io/sprinboot3_wrong_loggings/


```text
.RepositoryConfigurationExtensionSupport : Spring Data Redis - Could not safely identify store assignment for repository candidate interface com.readup.server.auth.infrastructure.SocialAccountJpaRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
```